### PR TITLE
secure workflow

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -14,6 +14,6 @@ jobs:
       shell: bash
       run: .kokoro/build.sh
     - name: Unmanaged dependency check
-      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.32.0
+      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.33.0
       with:
         bom-path: pom.xml

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.32.0"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.33.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.32.0"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.33.0"
 }
 
 env_vars: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [0.131.10-alpha](https://github.com/googleapis/java-logging-logback/compare/v0.131.9-alpha...v0.131.10-alpha) (2024-08-02)
+
+
+### Dependencies
+
+* Update dependency com.google.cloud:google-cloud-logging to v3.20.0 ([#1351](https://github.com/googleapis/java-logging-logback/issues/1351)) ([e3634d7](https://github.com/googleapis/java-logging-logback/commit/e3634d70284d2f80c03072e9aecd93b505f22551))
+* Update dependency com.google.cloud:sdk-platform-java-config to v3.33.0 ([#1349](https://github.com/googleapis/java-logging-logback/issues/1349)) ([47fc8f1](https://github.com/googleapis/java-logging-logback/commit/47fc8f1745c5852ad8cff429715d2dbfbd4301ee))
+* Update dependency org.easymock:easymock to v5.4.0 ([#1350](https://github.com/googleapis/java-logging-logback/issues/1350)) ([4c752fc](https://github.com/googleapis/java-logging-logback/commit/4c752fc6fc5d5cb512dc9630b758bb8092baadb6))
+
 ## [0.131.9-alpha](https://github.com/googleapis/java-logging-logback/compare/v0.131.8-alpha...v0.131.9-alpha) (2024-06-26)
 
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.131.8-alpha</version>
+  <version>0.131.9-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging-logback:0.131.8-alpha'
+implementation 'com.google.cloud:google-cloud-logging-logback:0.131.9-alpha'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.131.8-alpha"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.131.9-alpha"
 ```
 <!-- {x-version-update-end} -->
 
@@ -299,7 +299,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging-logback/java11.html
 [stability-image]: https://img.shields.io/badge/stability-preview-yellow
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging-logback.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging-logback/0.131.8-alpha
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging-logback/0.131.9-alpha
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <logback.version>1.2.13</logback.version>
     <easymock.version>5.4.0</easymock.version>
     <truth.version>1.4.4</truth.version>
-    <logging.version>3.19.0</logging.version>
+    <logging.version>3.20.0</logging.version>
     <slf4j.version>1.7.36</slf4j.version>
     <google.api-common.version>1.10.1</google.api-common.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.131.10-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
+  <version>0.131.10-alpha</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging Logback Appender</name>
   <url>https://github.com/googleapis/java-logging-logback</url>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.2</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.131.9-alpha</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
+  <version>0.131.10-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging Logback Appender</name>
   <url>https://github.com/googleapis/java-logging-logback</url>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <logback.version>1.2.13</logback.version>
-    <easymock.version>5.3.0</easymock.version>
+    <easymock.version>5.4.0</easymock.version>
     <truth.version>1.4.2</truth.version>
     <logging.version>3.19.0</logging.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <logback.version>1.2.13</logback.version>
     <easymock.version>5.4.0</easymock.version>
-    <truth.version>1.4.2</truth.version>
+    <truth.version>1.4.4</truth.version>
     <logging.version>3.19.0</logging.version>
     <slf4j.version>1.7.36</slf4j.version>
     <google.api-common.version>1.10.1</google.api-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.32.0</version>
+    <version>3.33.0</version>
   </parent>
 
   <developers>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging-logback</artifactId>
-      <version>0.131.8-alpha</version>
+      <version>0.131.9-alpha</version>
     </dependency>
     <!-- [END logging-logback_install_without_bom] -->
 

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging-logback</artifactId>
-      <version>0.131.7-alpha</version>
+      <version>0.131.8-alpha</version>
     </dependency>
     <!-- [END logging-logback_install_without_bom] -->
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.14</version>
+        <version>1.7.0</version>
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging-logback</artifactId>
-      <version>0.131.10-alpha-SNAPSHOT</version>
+      <version>0.131.10-alpha</version>
     </dependency>
     <!-- {x-version-update-end} -->
 

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging-logback</artifactId>
-      <version>0.131.9-alpha</version>
+      <version>0.131.10-alpha-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
 

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.40.0</version>
+        <version>26.43.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -122,7 +122,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   // See
   // https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
   // {x-version-update-start:google-cloud-logging-logback:current}
-  public static final String DEFAULT_INSTRUMENTATION_VERSION = "0.131.9-alpha";
+  public static final String DEFAULT_INSTRUMENTATION_VERSION = "0.131.10-alpha-SNAPSHOT";
   // {x-version-update-end}
   private static boolean instrumentationAdded = false;
   private static final Object instrumentationLock = new Object();

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -122,7 +122,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   // See
   // https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
   // {x-version-update-start:google-cloud-logging-logback:current}
-  public static final String DEFAULT_INSTRUMENTATION_VERSION = "0.131.10-alpha-SNAPSHOT";
+  public static final String DEFAULT_INSTRUMENTATION_VERSION = "0.131.10-alpha";
   // {x-version-update-end}
   private static boolean instrumentationAdded = false;
   private static final Object instrumentationLock = new Object();

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-logging-logback:0.131.9-alpha:0.131.9-alpha
+google-cloud-logging-logback:0.131.9-alpha:0.131.10-alpha-SNAPSHOT

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-logging-logback:0.131.9-alpha:0.131.10-alpha-SNAPSHOT
+google-cloud-logging-logback:0.131.10-alpha:0.131.10-alpha


### PR DESCRIPTION
- **chore(main): release 0.131.10-alpha-SNAPSHOT (#1345)**
- **chore(deps): update dependency com.google.cloud:google-cloud-logging-logback to v0.131.8-alpha (#1337)**
- **deps: update dependency org.easymock:easymock to v5.4.0 (#1350)**
- **deps: update dependency com.google.cloud:sdk-platform-java-config to v3.33.0 (#1349)**
- **test(deps): update dependency com.google.truth:truth to v1.4.4 (#1347)**
- **build(deps): update dependency org.apache.maven.plugins:maven-project-info-reports-plugin to v3.6.2 (#1339)**
- **chore(deps): update dependency com.google.cloud:libraries-bom to v26.43.0 (#1338)**
- **chore(deps): update dependency com.google.cloud:google-cloud-logging-logback to v0.131.9-alpha (#1353)**
- **test(deps): update dependency com.google.truth:truth to v1.4.4 (#1346)**
- **build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.7.0 (#1334)**
- **deps: update dependency com.google.cloud:google-cloud-logging to v3.20.0 (#1351)**
- **chore(main): release 0.131.10-alpha (#1352)**
- **chore: secure hermetic build workflow**
